### PR TITLE
Sort limit scope label values

### DIFF
--- a/src/main/java/dev/vality/exporter/limits/service/LimitsService.java
+++ b/src/main/java/dev/vality/exporter/limits/service/LimitsService.java
@@ -178,6 +178,7 @@ public class LimitsService {
                 })
                 .stream()
                 .flatMap(stringObjectMap -> stringObjectMap.keySet().stream())
+                .sorted()
                 .collect(Collectors.collectingAndThen(
                         Collectors.joining(","),
                         s -> Objects.equals(s, "") ? "all" : s));


### PR DESCRIPTION
Сортировка нужна, чтобы можно было закладываться на значение в лейбле, понимая, в каком порядке будут указаны скоупы.